### PR TITLE
Change function name _extension to extension.py

### DIFF
--- a/savona/exporter/html.py
+++ b/savona/exporter/html.py
@@ -44,7 +44,7 @@ class HTMLExporter(Exporter):
             self.config['title'] = ''
 
     @property
-    def _extension(self):
+    def extension(self):
         return '.html'
 
     def export(self, notebook_path, output_path):


### PR DESCRIPTION
 Change function name _extension.py to extension.py in exporter/html.py in order to call the corresponding function and not get error not implemented