### PR TITLE
Fixed the filename of the exporter file

### DIFF
--- a/savona/exporter/__init__.py
+++ b/savona/exporter/__init__.py
@@ -12,8 +12,8 @@ logger = logging.getLogger(__name__)
 
 class Exporter:
     def _write_output(self, output_path: Path, filename: str, body):
-        output_path = (output_path.parent /
-                       (output_path.stem + self.extension))
+        output_path = (output_path /
+                       (filename + self.extension))
         with open(output_path, 'w') as file:
             file.write(body)
 


### PR DESCRIPTION
The module was exporting the converter file in the previous folder of the origin file. Also, It was putting as a filename the name of the folder and no the name of the origin file.